### PR TITLE
Targets and topics admin

### DIFF
--- a/app/admin/targets.rb
+++ b/app/admin/targets.rb
@@ -1,0 +1,17 @@
+ActiveAdmin.register Target do
+  actions :all, except: %i[new edit]
+
+  index do
+    selectable_column
+    id_column
+    column :title
+    column :radius
+    column :latitude
+    column :longitude
+    column :created_at
+    column :updated_at
+    column :user
+    column :topic
+    actions
+  end
+end

--- a/app/admin/topics.rb
+++ b/app/admin/topics.rb
@@ -1,0 +1,9 @@
+ActiveAdmin.register Topic do
+  permit_params :name, :image
+
+  form do |f|
+    f.input :name
+    f.input :image, as: :file
+    actions
+  end
+end


### PR DESCRIPTION
### **Feature:**
As an admin I should be able to create/edit/delete new topics for targets.
As an admin I should be able to see all the targets in the system.
As an admin I should be able to filter targets by topic.

### **Trello reference:**
https://trello.com/c/BGb28t1y
https://trello.com/c/knItldMB
https://trello.com/c/F2C8ttLB

### **Description:**
Add support for CRUD topics in the admin.
Add support for view and edit delete targets in the admin.
Add filters by default, including filtering targets by topic.

**Topics list:**

<img width="1425" alt="Screen Shot 2021-06-03 at 19 33 23" src="https://user-images.githubusercontent.com/13893921/120720508-947e8e00-c4a2-11eb-8cba-e8b83f712097.png">



**Topics update:**

<img width="1200" alt="Screen Shot 2021-06-03 at 19 34 30" src="https://user-images.githubusercontent.com/13893921/120720592-bd068800-c4a2-11eb-8663-775daf12334e.png">


**Targets list:**

<img width="1416" alt="Screen Shot 2021-06-03 at 19 30 02" src="https://user-images.githubusercontent.com/13893921/120720247-20dc8100-c4a2-11eb-92b8-cd23ca4fb07b.png">



