### PR TITLE
Add unread messages count in conversation

### DIFF
--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -3,6 +3,7 @@ module Api
     class MessagesController < Api::V1::ApiController
       def index
         @messages = conversation.messages.page(page)
+        conversation.mark_messages_as_read(current_user)
       end
 
       private

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -2,10 +2,12 @@
 #
 # Table name: conversations
 #
-#  id         :bigint           not null, primary key
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  match_id   :bigint           not null
+#  id                          :bigint           not null, primary key
+#  first_user_unread_messages  :integer          default(0)
+#  second_user_unread_messages :integer          default(0)
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#  match_id                    :bigint           not null
 #
 # Indexes
 #
@@ -30,10 +32,34 @@ class Conversation < ApplicationRecord
     users.where.not(id: user.id)&.first
   end
 
+  def mark_messages_as_read(user)
+    if first?(user)
+      update!(first_user_unread_messages: 0)
+    else
+      update!(second_user_unread_messages: 0)
+    end
+  end
+
+  def new_messages_count(user)
+    first?(user) ? first_user_unread_messages : second_user_unread_messages
+  end
+
+  def increase_unread(user)
+    if first?(user)
+      update!(first_user_unread_messages: first_user_unread_messages + 1)
+    else
+      update!(second_user_unread_messages: second_user_unread_messages + 1)
+    end
+  end
+
   private
 
   def add_users_to_conversation
     users << [match.first_user, match.second_user]
+  end
+
+  def first?(user)
+    match.first_user == user
   end
 
   def users_uniqueness

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -34,6 +34,7 @@ class Message < ApplicationRecord
 
   def broadcast_message
     ConversationChannel.broadcast_to(conversation, render_body(body))
+    conversation.increase_unread(user)
   end
 
   def render_body(body)

--- a/app/views/api/v1/conversations/_info.json.jbuilder
+++ b/app/views/api/v1/conversations/_info.json.jbuilder
@@ -1,1 +1,2 @@
 json.extract! conversation, :id, :match_id
+json.new_messages_count conversation.new_messages_count(current_user)

--- a/db/migrate/20210624180831_add_unread_messages_count.rb
+++ b/db/migrate/20210624180831_add_unread_messages_count.rb
@@ -1,0 +1,8 @@
+class AddUnreadMessagesCount < ActiveRecord::Migration[6.1]
+  def change
+    change_table :conversations, bulk: true do |t|
+      t.integer :first_user_unread_messages, default: 0
+      t.integer :second_user_unread_messages, default: 0
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_23_173349) do
+ActiveRecord::Schema.define(version: 2021_06_24_180831) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,8 +60,6 @@ ActiveRecord::Schema.define(version: 2021_06_23_173349) do
   create_table "active_storage_variant_records", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
@@ -88,6 +86,8 @@ ActiveRecord::Schema.define(version: 2021_06_23_173349) do
     t.bigint "match_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "first_user_unread_messages", default: 0
+    t.integer "second_user_unread_messages", default: 0
     t.index ["match_id"], name: "index_conversations_on_match_id"
   end
 
@@ -156,7 +156,7 @@ ActiveRecord::Schema.define(version: 2021_06_23_173349) do
     t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
-    t.integer "targets_count", default: 0, null: false
+    t.integer "targets_count"
     t.string "first_name", default: ""
     t.string "last_name", default: ""
     t.string "push_token"
@@ -170,7 +170,6 @@ ActiveRecord::Schema.define(version: 2021_06_23_173349) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "conversations", "matches"
-  add_foreign_key "matches", "targets"
   add_foreign_key "messages", "conversations"
   add_foreign_key "messages", "users"
   add_foreign_key "user_conversations", "conversations"

--- a/spec/channels/conversation_channel_spec.rb
+++ b/spec/channels/conversation_channel_spec.rb
@@ -51,5 +51,11 @@ describe ConversationChannel, type: :channel do
         message
       )
     end
+
+    it 'increases messages unread count' do
+      subject
+      conversation.reload
+      expect(conversation.first_user_unread_messages).to eq(1)
+    end
   end
 end

--- a/spec/factories/conversations.rb
+++ b/spec/factories/conversations.rb
@@ -2,10 +2,12 @@
 #
 # Table name: conversations
 #
-#  id         :bigint           not null, primary key
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  match_id   :bigint           not null
+#  id                          :bigint           not null, primary key
+#  first_user_unread_messages  :integer          default(0)
+#  second_user_unread_messages :integer          default(0)
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#  match_id                    :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -2,10 +2,12 @@
 #
 # Table name: conversations
 #
-#  id         :bigint           not null, primary key
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  match_id   :bigint           not null
+#  id                          :bigint           not null, primary key
+#  first_user_unread_messages  :integer          default(0)
+#  second_user_unread_messages :integer          default(0)
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#  match_id                    :bigint           not null
 #
 # Indexes
 #

--- a/spec/requests/api/v1/conversations/index_spec.rb
+++ b/spec/requests/api/v1/conversations/index_spec.rb
@@ -18,6 +18,11 @@ describe 'GET api/v1/conversations', type: :request do
     expect(json[:conversations].pluck([:id])).to match_array(conversations.pluck([:id]))
   end
 
+  it 'returns user unread messages' do
+    subject
+    expect(json[:conversations].pluck([:new_messages_count])).to match_array(conversations.pluck([:new_messages_count]))
+  end
+
   it 'does not return other\'s users conversations' do
     subject
     expect(json[:conversations].pluck([:id])).not_to include(other_user_conversations.pluck([:id]))

--- a/spec/requests/api/v1/conversations/messages/index_spec.rb
+++ b/spec/requests/api/v1/conversations/messages/index_spec.rb
@@ -4,7 +4,7 @@ describe 'GET api/v1/conversations/{id}/messages', type: :request do
   let(:other_user) { create(:user) }
   let(:match) { create(:match, first_user: user, second_user: second_user) }
   let(:other_match) { create(:match, first_user: user, second_user: other_user) }
-  let(:conversation) { create(:conversation, users: [user, second_user], match: match) }
+  let(:conversation) { create(:conversation, users: [user, second_user], match: match, first_user_unread_messages: 3) }
   let!(:messages) do
     create_list(:message, 3, user: user, conversation: conversation)
   end
@@ -29,6 +29,11 @@ describe 'GET api/v1/conversations/{id}/messages', type: :request do
 
   it 'returns the body of each one' do
     expect(json[:messages].pluck([:body])).to match_array(messages.pluck([:body]))
+  end
+
+  it 'mark messages as read' do
+    conversation.reload
+    expect(conversation.first_user_unread_messages).to eq(0)
   end
 
   it 'does not return other\'s users conversations messages' do


### PR DESCRIPTION
### **Feature:**
As a user I should be able to see the unread conversations count so I can easily identify them.


### **Trello reference:**
https://trello.com/c/iWvdvK4f


### **Description:**
This PR implements unread messages count.
